### PR TITLE
Add expiry compute failure test case

### DIFF
--- a/pkg/spotter/expiry_test.go
+++ b/pkg/spotter/expiry_test.go
@@ -41,62 +41,66 @@ func verifyNodeExpiry(t time.Time, eligibleWLs []TimeSpan) bool {
 //If the CET (CT+TTL) falls in a WhiteList Interval , it should be used as is
 func (suite *SpotterTestSuite) TestShouldSlotNodeExpTimeToOneOfElegibleWLInRandom() {
 	testData := []ExpiryTestData{
-		{
-			NodeName:           "Node-1",
-			CreationTime:       parseTime("Mon, 22 Jun 2020 10:10:00 +0000"),
-			WhitelistIntervals: []string{"00:00-06:00", "12:00-14:00"},
-			EligibleWLs: []TimeSpan{
-				{
-					Start: parseTime("Mon, 22 Jun 2020 12:00:00 +0000"),
-					End:   parseTime("Mon, 22 Jun 2020 14:00:00 +0000"),
-				},
-				{
-					Start: parseTime("Mon, 23 Jun 2020 00:00:00 +0000"),
-					End:   parseTime("Mon, 23 Jun 2020 06:00:00 +0000"),
-				},
-			},
-		},
-		{
-			NodeName:           "Node-2",
-			CreationTime:       parseTime("Mon, 22 Jun 2020 15:40:00 +0000"),
-			WhitelistIntervals: []string{"00:00-06:00", "12:00-14:00"},
-			EligibleWLs: []TimeSpan{
-				{
-					Start: parseTime("Mon, 23 Jun 2020 00:00:00 +0000"),
-					End:   parseTime("Mon, 23 Jun 2020 06:00:00 +0000"),
-				},
-				{
-					Start: parseTime("Mon, 23 Jun 2020 12:00:00 +0000"),
-					End:   parseTime("Mon, 23 Jun 2020 14:00:00 +0000"),
-				},
-			},
-		},
-		{
-			NodeName:           "Node-3",
-			CreationTime:       parseTime("Mon, 22 Jun 2020 00:40:00 +0000"),
-			WhitelistIntervals: []string{"00:00-06:00", "12:00-14:00"},
-			EligibleWLs: []TimeSpan{
-				{
-					Start: parseTime("Mon, 22 Jun 2020 12:00:00 +0000"),
-					End:   parseTime("Mon, 22 Jun 2020 14:00:00 +0000"),
-				},
-			},
-		},
-		{
-			NodeName:           "Node-4",
-			CreationTime:       parseTime("Mon, 22 Jun 2020 22:20:00 +0000"),
-			WhitelistIntervals: []string{"00:00-06:00", "12:00-14:00"},
-			EligibleWLs: []TimeSpan{
-				{
-					Start: parseTime("Mon, 23 Jun 2020 00:00:00 +0000"),
-					End:   parseTime("Mon, 23 Jun 2020 06:00:00 +0000"),
-				},
-				{
-					Start: parseTime("Mon, 23 Jun 2020 12:00:00 +0000"),
-					End:   parseTime("Mon, 23 Jun 2020 14:00:00 +0000"),
-				},
-			},
-		},
+		// Mingfei: these have to be commented out for the new test case to run because
+		// configMock.On(...).Return(...) can only be called once, the mock return value
+		// cannot be modified.
+		//
+		// {
+		// 	NodeName:           "Node-1",
+		// 	CreationTime:       parseTime("Mon, 22 Jun 2020 10:10:00 +0000"),
+		// 	WhitelistIntervals: []string{"00:00-06:00", "12:00-14:00"},
+		// 	EligibleWLs: []TimeSpan{
+		// 		{
+		// 			Start: parseTime("Mon, 22 Jun 2020 12:00:00 +0000"),
+		// 			End:   parseTime("Mon, 22 Jun 2020 14:00:00 +0000"),
+		// 		},
+		// 		{
+		// 			Start: parseTime("Mon, 23 Jun 2020 00:00:00 +0000"),
+		// 			End:   parseTime("Mon, 23 Jun 2020 06:00:00 +0000"),
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	NodeName:           "Node-2",
+		// 	CreationTime:       parseTime("Mon, 22 Jun 2020 15:40:00 +0000"),
+		// 	WhitelistIntervals: []string{"00:00-06:00", "12:00-14:00"},
+		// 	EligibleWLs: []TimeSpan{
+		// 		{
+		// 			Start: parseTime("Mon, 23 Jun 2020 00:00:00 +0000"),
+		// 			End:   parseTime("Mon, 23 Jun 2020 06:00:00 +0000"),
+		// 		},
+		// 		{
+		// 			Start: parseTime("Mon, 23 Jun 2020 12:00:00 +0000"),
+		// 			End:   parseTime("Mon, 23 Jun 2020 14:00:00 +0000"),
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	NodeName:           "Node-3",
+		// 	CreationTime:       parseTime("Mon, 22 Jun 2020 00:40:00 +0000"),
+		// 	WhitelistIntervals: []string{"00:00-06:00", "12:00-14:00"},
+		// 	EligibleWLs: []TimeSpan{
+		// 		{
+		// 			Start: parseTime("Mon, 22 Jun 2020 12:00:00 +0000"),
+		// 			End:   parseTime("Mon, 22 Jun 2020 14:00:00 +0000"),
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	NodeName:           "Node-4",
+		// 	CreationTime:       parseTime("Mon, 22 Jun 2020 22:20:00 +0000"),
+		// 	WhitelistIntervals: []string{"00:00-06:00", "12:00-14:00"},
+		// 	EligibleWLs: []TimeSpan{
+		// 		{
+		// 			Start: parseTime("Mon, 23 Jun 2020 00:00:00 +0000"),
+		// 			End:   parseTime("Mon, 23 Jun 2020 06:00:00 +0000"),
+		// 		},
+		// 		{
+		// 			Start: parseTime("Mon, 23 Jun 2020 12:00:00 +0000"),
+		// 			End:   parseTime("Mon, 23 Jun 2020 14:00:00 +0000"),
+		// 		},
+		// 	},
+		// },
 		{
 			NodeName:           "Node-5",
 			CreationTime:       parseTime("Thu, 18 Feb 2021 18:58:52 +0000"),


### PR DESCRIPTION
This:
1. adds a failed test case to expiry test, regarding to issue https://github.com/rapido-labs/silent-assassin/issues/25
2. fixed a existing failing test case in `TestShouldReturnETinSameTimeZoneAsCT`, it is comparing 2 pointers so it's unlikely they'll be equal
3. slightly modified `TestShouldSlotNodeExpTimeToOneOfElegibleWLInRandom` test function to allow passing in `WhitelistIntervals` as a test parameter

This PR is not meant to be merged, just raise an issue with expiry calculation
